### PR TITLE
Add recipient key entity and rules to have temporary access links

### DIFF
--- a/src/main/java/co/entomo/gdhcn/controller/GdhcnController.java
+++ b/src/main/java/co/entomo/gdhcn/controller/GdhcnController.java
@@ -61,9 +61,9 @@ public class GdhcnController
 	 */
 	@CrossOrigin(origins = "*", allowedHeaders = "*")
 	@GetMapping(value = "/v2/ips-json/{jsonId}", produces = {"application/json"})
-	public ResponseEntity<String> getIpsJson(@PathVariable("jsonId") String jsonId)
+	public ResponseEntity<String> getIpsJson(@PathVariable("jsonId") String jsonId, @RequestParam(value = "key", required = false) String key)
 	{
-		String jsonContent = gdhcnService.downloadJson(jsonId);
+		String jsonContent = gdhcnService.downloadJson(jsonId, key);
 		return ResponseEntity.of(Optional.of(jsonContent));
 	}
 	/**

--- a/src/main/java/co/entomo/gdhcn/entity/RecipientKey.java
+++ b/src/main/java/co/entomo/gdhcn/entity/RecipientKey.java
@@ -1,0 +1,37 @@
+package co.entomo.gdhcn.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.util.Date;
+
+/**
+ *  @author Sergio Penafiel
+ *  @organization Create SpA
+ */
+@Data
+@Entity
+@Table(name = "recipient_key")
+public class RecipientKey {
+
+	@Id
+	@Column(length = 36)
+	private String id;
+	
+	private String recipient;
+	
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date expiresOn;
+	
+	@CreationTimestamp
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "created_at")
+    private Date createdAt;
+
+	private String jsonId;
+
+}

--- a/src/main/java/co/entomo/gdhcn/repository/RecipientKeyRepository.java
+++ b/src/main/java/co/entomo/gdhcn/repository/RecipientKeyRepository.java
@@ -1,0 +1,25 @@
+package co.entomo.gdhcn.repository;
+
+import co.entomo.gdhcn.entity.QrCode;
+import co.entomo.gdhcn.entity.RecipientKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ *
+ *  @author Sergio Penafiel
+ *  @organization Create SpA
+ * Repository interface for managing {@link RecipientKey} entities.
+ * Extends {@link JpaRepository} to provide basic CRUD operations.
+ */
+public interface RecipientKeyRepository extends JpaRepository<RecipientKey, String> {
+    /**
+     * Finds a {@link RecipientKey} entity by its ID and jsonId.
+     *
+     * @param id     the ID of the {@link RecipientKey}.
+     * @param jsonId the jsonId associated with the {@link RecipientKey}.
+     * @return an {@link Optional} containing the found {@link RecipientKey}, or {@code Optional.empty()} if no matching entity is found.
+     */
+    Optional<RecipientKey> findByIdAndJsonId(String id, String jsonId);
+}

--- a/src/main/java/co/entomo/gdhcn/service/GdhcnService.java
+++ b/src/main/java/co/entomo/gdhcn/service/GdhcnService.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import co.entomo.gdhcn.exceptions.GdhcnValidationException;
 import co.entomo.gdhcn.vo.ManifestRequest;
 import co.entomo.gdhcn.vo.QrCodeRequest;
-import co.entomo.gdhcn.vo.StepStatus;
 import co.entomo.gdhcn.vo.ValidateCwtResponse;
 
 /**
@@ -56,7 +55,8 @@ public interface GdhcnService {
 	 * Downloads standard JSON data (not JWE) based on the provided JSON identifier.
 	 *
 	 * @param jsonId the identifier for the JSON data to be downloaded.
+	 * @param key the recipient key to download the JSON
 	 * @return a {@code String} representing the JSON data.
 	 */
-	String downloadJson(String jsonId);
+	String downloadJson(String jsonId, String key);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=entomo-gdhcn-ms
 server.port=8082
 spring.profiles.active = fileSystem
-filesystem.baseLocation =
+filesystem.baseLocation = /Users/sergio/Create/gdhcn-validator
 filesystem.folderName = json
 
 aws.bucket.access.key=
@@ -9,9 +9,9 @@ aws.bucket.access.secret=
 aws.bucket.s3.bucket.name=gdhcn-ips
 aws.bucket.s3.json.folder=json
 
-gdhcn.baseUrl=https://gdhcn-validator.net
+gdhcn.baseUrl=http://localhost:8082
 gdhcn.dev.url = https://tng-dev.who.int
-spring.datasource.url =
+spring.datasource.url =jdbc:postgresql://localhost:5432/gdhcn
 spring.datasource.username = 
 spring.datasource.password =
 spring.jpa.hibernate.ddl-auto = update
@@ -20,11 +20,12 @@ spring.datasource.driver-class-name = org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 #spring.jpa.properties.hibernate.jdbc.time_zone = UTC
 
-tng.tls.pem =
-tng.tls.key = 
+tng.tls.pem = /Users/sergio/Create/gdhcn-validator/secret/TLS.pem
+tng.tls.key = /Users/sergio/Create/gdhcn-validator/secret/TLS.key
 ## Your country code
-tng.country =
+tng.country = XL
 ## Your DSC Private
-tng.dsc.privateKey =
-tng.dsc.privateKey.kid =
+tng.dsc.privateKey = /Users/sergio/Create/gdhcn-validator/secret/DSCpriv.key
+tng.dsc.privateKey.kid = UUuJcwmjoJM=
 
+recipient.keyDurationMinutes = 5

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=entomo-gdhcn-ms
 server.port=8082
 spring.profiles.active = fileSystem
-filesystem.baseLocation = /Users/sergio/Create/gdhcn-validator
+filesystem.baseLocation =
 filesystem.folderName = json
 
 aws.bucket.access.key=
@@ -9,9 +9,9 @@ aws.bucket.access.secret=
 aws.bucket.s3.bucket.name=gdhcn-ips
 aws.bucket.s3.json.folder=json
 
-gdhcn.baseUrl=http://localhost:8082
+gdhcn.baseUrl=https://gdhcn-validator.net
 gdhcn.dev.url = https://tng-dev.who.int
-spring.datasource.url =jdbc:postgresql://localhost:5432/gdhcn
+spring.datasource.url =
 spring.datasource.username = 
 spring.datasource.password =
 spring.jpa.hibernate.ddl-auto = update
@@ -20,12 +20,12 @@ spring.datasource.driver-class-name = org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 #spring.jpa.properties.hibernate.jdbc.time_zone = UTC
 
-tng.tls.pem = /Users/sergio/Create/gdhcn-validator/secret/TLS.pem
-tng.tls.key = /Users/sergio/Create/gdhcn-validator/secret/TLS.key
+tng.tls.pem =
+tng.tls.key = 
 ## Your country code
-tng.country = XL
+tng.country =
 ## Your DSC Private
-tng.dsc.privateKey = /Users/sergio/Create/gdhcn-validator/secret/DSCpriv.key
-tng.dsc.privateKey.kid = UUuJcwmjoJM=
+tng.dsc.privateKey =
+tng.dsc.privateKey.kid = 
 
 recipient.keyDurationMinutes = 5


### PR DESCRIPTION
# Summary

- Add `RecipientKey` entity and repository to persists recipient access keys
- Modify the manifest endpoint to create a new recipient access key
- Modify the get IPS endpoint to provide the document only if the recipient key is valid
- Add property `recipient.keyDurationMinutes` to set the expiration time of the temporary links (defaults to 5 minutes)